### PR TITLE
Adjust imports to match the now-recommended "import ops" style (section 2)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: blacken-docs
         additional_dependencies: [black]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,19 +5,13 @@
 # Learn more at: https://juju.is/docs/sdk
 import logging
 
-from ops.charm import CharmBase
-from ops.main import main
-from ops.model import ActiveStatus
-from ops.model import BlockedStatus
-from ops.model import MaintenanceStatus
-from ops.model import WaitingStatus
-from ops.pebble import Layer
+import ops
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
 
 
-class FastAPIDemoCharm(CharmBase):
+class FastAPIDemoCharm(ops.CharmBase):
     """Charm the service."""
 
     def __init__(self, *args):
@@ -32,7 +26,7 @@ class FastAPIDemoCharm(CharmBase):
         logger.debug("New application port is requested: %s", port)
 
         if int(port) == 22:
-            self.unit.status = BlockedStatus("Invalid port number, 22 is reserved for SSH")
+            self.unit.status = ops.BlockedStatus("Invalid port number, 22 is reserved for SSH")
             return
 
         self._update_layer_and_restart(None)
@@ -49,7 +43,7 @@ class FastAPIDemoCharm(CharmBase):
 
         # Learn more about statuses in the SDK docs:
         # https://juju.is/docs/sdk/constructs#heading--statuses
-        self.unit.status = MaintenanceStatus("Assembling pod spec")
+        self.unit.status = ops.MaintenanceStatus("Assembling pod spec")
         if self.container.can_connect():
             new_layer = self._pebble_layer.to_dict()
             # Get the current pebble layer config
@@ -62,9 +56,9 @@ class FastAPIDemoCharm(CharmBase):
                 self.container.restart(self.pebble_service_name)
                 logger.info(f"Restarted '{self.pebble_service_name}' service")
 
-            self.unit.status = ActiveStatus()
+            self.unit.status = ops.ActiveStatus()
         else:
-            self.unit.status = WaitingStatus("Waiting for Pebble in workload container")
+            self.unit.status = ops.WaitingStatus("Waiting for Pebble in workload container")
 
     @property
     def _pebble_layer(self):
@@ -89,8 +83,8 @@ class FastAPIDemoCharm(CharmBase):
                 }
             },
         }
-        return Layer(pebble_layer)
+        return ops.pebble.Layer(pebble_layer)
 
 
 if __name__ == "__main__":  # pragma: nocover
-    main(FastAPIDemoCharm)
+    ops.main(FastAPIDemoCharm)


### PR DESCRIPTION
As part of canonical/operator#921, we're updating the docs to use the now-recommended "import ops" style, that is, instead of:

```python
from ops.charm import CharmBase
from ops.main import main
class MyC(CharmBase):
    ...
if __name__ == "__main__":
    main(MyC)
```

We prefer people do:

```python
import ops
class MyC(ops.CharmBase):
    ...
if __name__ == "__main__":
    ops.main(MyC)
```

The docs have been updated (as part of #921), so ideally the linked repo would be as well. I'll create a PR for each section of the tutorial - this is for #2 ("Make your charm configurable").

This includes a drive-by version bump to isort, because the current one's dependencies break pre-commit.  See PyCQA/isort:#2079 for details.