### PR TITLE
Prefer catching ConnectionError to using can_connect

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: blacken-docs
         additional_dependencies: [black]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,6 +16,7 @@ from ops.model import ActiveStatus
 from ops.model import BlockedStatus
 from ops.model import MaintenanceStatus
 from ops.model import WaitingStatus
+from ops.pebble import ConnectionError
 from ops.pebble import Layer
 
 # Log messages can be retrieved using juju debug-log
@@ -118,8 +119,8 @@ class FastAPIDemoCharm(CharmBase):
         # Learn more about statuses in the SDK docs:
         # https://juju.is/docs/sdk/constructs#heading--statuses
         self.unit.status = MaintenanceStatus("Assembling pod spec")
-        if self.container.can_connect():
-            new_layer = self._pebble_layer.to_dict()
+        new_layer = self._pebble_layer.to_dict()
+        try:
             # Get the current pebble layer config
             services = self.container.get_plan().to_dict().get("services", {})
             if services != new_layer["services"]:
@@ -133,7 +134,7 @@ class FastAPIDemoCharm(CharmBase):
             # add workload version in juju status
             self.unit.set_workload_version(self.version)
             self.unit.status = ActiveStatus()
-        else:
+        except ConnectionError:
             self.unit.status = WaitingStatus("Waiting for Pebble in workload container")
 
     @property
@@ -208,14 +209,16 @@ class FastAPIDemoCharm(CharmBase):
     @property
     def version(self) -> str:
         """Reports the current workload (FastAPI app) version."""
-        if self.container.can_connect() and self.container.get_services(self.pebble_service_name):
-            try:
+        try:
+            if self.container.get_services(self.pebble_service_name):
                 return self._request_version()
-            # Catching Exception is not ideal, but we don't care much for the error here, and just
-            # default to setting a blank version since there isn't much the admin can do!
-            except Exception as e:
-                logger.warning("unable to get version from API: %s", str(e))
-                logger.exception(e)
+        except ConnectionError:
+            pass
+        # Catching Exception is not ideal, but we don't care much for the error here, and just
+        # default to setting a blank version since there isn't much the admin can do!
+        except Exception as e:
+            logger.warning("unable to get version from API: %s", str(e))
+            logger.exception(e)
         return ""
 
     def _request_version(self) -> str:


### PR DESCRIPTION
Using can_connect() as a guard introduces a race condition (because it's a point-in-time check), and the Charm-Tech team is trying to discourage its use, in favour of catching ConnectionError (which ought to be done anyway). It would be great to have the tutorial follow this practice rather than encourage new charmers to use can_connect() in this way.

In a production charm I would expect tighter wrapping around the Pebble calls, probably with some sort of function (maybe decorator/context manager) and some retrying, but keeping this simple for the tutorial.

Also includes the previously done (but not merged) fix for the bad version of isort.