### PR TITLE
Prefer catching ConnectionError to using can_connect

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: blacken-docs
         additional_dependencies: [black]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
Using can_connect() as a guard introduces a race condition (because it's a point-in-time check), and the Charm-Tech team is trying to discourage its use, in favour of catching ConnectionError (which ought to be done anyway). It would be great to have the tutorial follow this practice rather than encourage new charmers to use can_connect() in this way.

In a production charm I would expect tighter wrapping around the Pebble calls, probably with some sort of function (maybe decorator/context manager) and some retrying, but keeping this simple for the tutorial.

Also includes the previously done (but not merged) fix for the bad version of isort.