### PR TITLE
Prefer catching ConnectionError to using can_connect

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: blacken-docs
         additional_dependencies: [black]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright 2023 benjamin
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = METADATA["name"]
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest):
+    """Build the charm-under-test and deploy it together with related charms.
+
+    Assert on the unit status before any relations/configurations take place.
+    """
+    # Build and deploy charm from local source folder
+    charm = await ops_test.build_charm(".")
+    resources = {
+        "demo-server-image": METADATA["resources"]["demo-server-image"][
+            "upstream-source"
+        ]
+    }
+
+    # Deploy the charm and wait for waiting/idle status
+    # The app will not be in active status as this requires a database relation
+    await asyncio.gather(
+        ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME),
+        ops_test.model.wait_for_idle(
+            apps=[APP_NAME], status="waiting", raise_on_blocked=True, timeout=1000
+        ),
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_database_integration(ops_test: OpsTest):
+    """Verify that the charm integrates with the database.
+
+    Assert that the charm is active if the integration is established.
+    """
+    await ops_test.model.deploy(
+        application_name="postgresql-k8s",
+        entity_url="https://charmhub.io/postgresql-k8s",
+        channel="14/stable",
+    )
+    await ops_test.model.integrate(f"{APP_NAME}", "postgresql-k8s")
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1000
+    )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more at: https://juju.is/docs/sdk
+from charm import FastAPIDemoCharm
+from scenario import PeerRelation, Relation, State, Context, Container, Action
+
+import ops
+import ops.testing
+import unittest
+import unittest.mock
+
+
+class TestCharm(unittest.TestCase):
+    def setUp(self):
+        self.harness = ops.testing.Harness(FastAPIDemoCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+    @unittest.mock.patch(
+        "charm.FastAPIDemoCharm.version", new_callable=unittest.mock.PropertyMock
+    )
+    @unittest.mock.patch("charm.FastAPIDemoCharm.fetch_postgres_relation_data")
+    def test_pebble_layer(self, mock_fetch_postgres_relation_data, mock_version):
+        # Expected plan after Pebble ready with default config
+        expected_plan = {
+            "services": {
+                "fastapi-service": {
+                    "override": "replace",
+                    "summary": "fastapi demo",
+                    "command": "uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000",
+                    "startup": "enabled",
+                    "environment": {
+                        "DEMO_SERVER_DB_HOST": None,
+                        "DEMO_SERVER_DB_PASSWORD": None,
+                        "DEMO_SERVER_DB_PORT": None,
+                        "DEMO_SERVER_DB_USER": None,
+                    },
+                }
+            }
+        }
+        mock_fetch_postgres_relation_data.return_value = {}
+        mock_version.return_value = "1.0.0"
+
+        # Simulate the container coming up and emission of pebble-ready event
+        self.harness.container_pebble_ready("demo-server")
+        # Get the plan now we've run PebbleReady
+        updated_plan = self.harness.get_container_pebble_plan("demo-server").to_dict()
+        # Check we've got the plan we expected
+        self.assertEqual(expected_plan, updated_plan)
+        # Check the service was started
+        service = self.harness.model.unit.get_container("demo-server").get_service(
+            "fastapi-service"
+        )
+        self.assertTrue(service.is_running())
+        # Ensure we set an ActiveStatus with no message
+        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
+
+    @unittest.mock.patch("charm.LogProxyConsumer")
+    @unittest.mock.patch("charm.MetricsEndpointProvider")
+    @unittest.mock.patch("charm.GrafanaDashboardProvider")
+    def test_get_db_info_action(self, *_):
+        # use scenario.Context to declare what charm we are testing
+        ctx = Context(
+            FastAPIDemoCharm,
+            meta={
+                "name": "demo-api-charm",
+                "containers": {"demo-server": {}},
+                "peers": {"fastapi-peer": {"interface": "fastapi_demo_peers"}},
+                "requires": {
+                    "database": {
+                        "interface": "postgresql_client",
+                    }
+                },
+            },
+            config={
+                "options": {
+                    "server-port": {
+                        "default": 8000,
+                    }
+                }
+            },
+            actions={
+                "get-db-info": {
+                    "params": {"show-password": {"default": False, "type": "boolean"}}
+                }
+            },
+        )
+
+        # declare the input state
+        state_in = State(
+            leader=True,
+            relations=[
+                Relation(
+                    endpoint="database",
+                    interface="postgresql_client",
+                    remote_app_name="postgresql-k8s",
+                    local_unit_data={},
+                    remote_app_data={
+                        "endpoints": "127.0.0.1:5432",
+                        "username": "foo",
+                        "password": "bar",
+                    },
+                ),
+            ],
+            containers=[
+                Container(name="demo-server", can_connect=True),
+            ],
+        )
+
+        # ACT: run the action with the defined state and collect the output.
+        action = Action("get-db-info", {"show-password": True})
+        action_out = ctx.run_action(action, state_in)
+
+        assert action_out.results == {
+            "db-host": "127.0.0.1",
+            "db-port": "5432",
+            "db-username": "foo",
+            "db-password": "bar",
+        }

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,40 @@
+# Copyright 2023 benjamin
+# See LICENSE file for licensing details.
+
+[tox]
+no_package = True
+skip_missing_interpreters = True
+min_version = 4.0.0
+env_list = unit
+
+[vars]
+src_path = {tox_root}/src
+tests_path = {tox_root}/tests
+
+[testenv]
+set_env =
+    PYTHONPATH = {tox_root}/lib:{[vars]src_path}
+    PYTHONBREAKPOINT=pdb.set_trace
+    PY_COLORS=1
+pass_env =
+    PYTHONPATH
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
+
+[testenv:unit]
+description = Run unit tests
+deps =
+    pytest
+    cosl
+    ops-scenario
+    coverage[toml]
+    -r {tox_root}/requirements.txt
+commands =
+    coverage run --source={[vars]src_path} \
+                 -m pytest \
+                 --tb native \
+                 -v \
+                 -s \
+                 {posargs} \
+                 {[vars]tests_path}/unit
+    coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ pass_env =
     CHARM_BUILD_DIR
     MODEL_SETTINGS
 
+
 [testenv:unit]
 description = Run unit tests
 deps =
@@ -38,3 +39,18 @@ commands =
                  {posargs} \
                  {[vars]tests_path}/unit
     coverage report
+    
+[testenv:integration]
+description = Run integration tests
+deps =
+    pytest
+    juju
+    pytest-operator
+    -r {tox_root}/requirements.txt
+commands =
+    pytest -v \
+           -s \
+           --tb native \
+           --log-cli-level=INFO \
+           {posargs} \
+           {[vars]tests_path}/integration


### PR DESCRIPTION
Using can_connect() as a guard introduces a race condition (because it's a point-in-time check), and the Charm-Tech team is trying to discourage its use, in favour of catching ConnectionError (which ought to be done anyway). It would be great to have the tutorial follow this practice rather than encourage new charmers to use can_connect() in this way.

In a production charm I would expect tighter wrapping around the Pebble calls, probably with some sort of function (maybe decorator/context manager) and some retrying, but keeping this simple for the tutorial.

Also includes the previously done (but not merged) fix for the bad version of isort.