### PR TITLE
fix: make sure a Rust compiler is available when building

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,6 +10,12 @@ bases:
     - name: ubuntu
       channel: "22.04"
 
+parts:
+  charm:
+    build-packages:
+      # Required for the cos-lite packages, which have a Rust dependency.
+      - cargo
+
 # This file populates the Overview on Charmhub.
 # See https://juju.is/docs/sdk/metadata-reference for a checklist and guidance.
 


### PR DESCRIPTION
The COS-lite packages all require packages that have Rust implementations, and the build image doesn't have a Rust compiler, so we need to tell charmcraft to install one.

I've updated the [tutorial text](https://juju.is/docs/sdk/observe-your-charm-with-cos-lite) as well.