### PR TITLE
01_create_minimal_charm: Add type hints and lightly refactor

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -14,18 +14,19 @@ logger = logging.getLogger(__name__)
 class FastAPIDemoCharm(ops.CharmBase):
     """Charm the service."""
 
-    def __init__(self, framework):
+    def __init__(self, framework: ops.Framework) -> None:
         super().__init__(framework)
         self.pebble_service_name = "fastapi-service"
-        framework.observe(self.on.demo_server_pebble_ready, self._on_demo_server_pebble_ready)
+        framework.observe(self.on["demo-server"].pebble_ready, self._on_demo_server_pebble_ready)
 
-    def _on_demo_server_pebble_ready(self, event):
+    def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
         """Define and start a workload using the Pebble API.
 
         Change this example to suit your needs. You'll need to specify the right entrypoint and
         environment configuration for your specific workload.
 
-        Learn more about interacting with Pebble at at https://juju.is/docs/sdk/pebble.
+        Learn more about interacting with Pebble at https://juju.is/docs/sdk/pebble
+        Learn more about Pebble layers at https://github.com/canonical/pebble
         """
         # Get a reference the container attribute on the PebbleReadyEvent
         container = event.workload
@@ -38,8 +39,8 @@ class FastAPIDemoCharm(ops.CharmBase):
         self.unit.status = ops.ActiveStatus()
 
     @property
-    def _pebble_layer(self):
-        """Return a dictionary representing a Pebble layer."""
+    def _pebble_layer(self) -> ops.pebble.Layer:
+        """Return a Layer object representing a Pebble layer."""
         command = " ".join(
             [
                 "uvicorn",
@@ -48,7 +49,7 @@ class FastAPIDemoCharm(ops.CharmBase):
                 "--port=8000",
             ]
         )
-        pebble_layer = {
+        pebble_layer: ops.pebble.LayerDict = {
             "summary": "FastAPI demo service",
             "description": "pebble config layer for FastAPI demo server",
             "services": {

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,8 +16,8 @@ class FastAPIDemoCharm(ops.CharmBase):
 
     def __init__(self, framework: ops.Framework) -> None:
         super().__init__(framework)
-        self.pebble_service_name = "fastapi-service"
-        framework.observe(self.on["demo-server"].pebble_ready, self._on_demo_server_pebble_ready)
+        self.pebble_service_name = 'fastapi-service'
+        framework.observe(self.on.demo_server_pebble_ready, self._on_demo_server_pebble_ready)
 
     def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
         """Define and start a workload using the Pebble API.
@@ -26,12 +26,13 @@ class FastAPIDemoCharm(ops.CharmBase):
         environment configuration for your specific workload.
 
         Learn more about interacting with Pebble at https://juju.is/docs/sdk/pebble
-        Learn more about Pebble layers at https://github.com/canonical/pebble
+        Learn more about Pebble layers at
+            https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/layers/
         """
         # Get a reference the container attribute on the PebbleReadyEvent
         container = event.workload
         # Add initial Pebble config layer using the Pebble API
-        container.add_layer("fastapi_demo", self._pebble_layer, combine=True)
+        container.add_layer('fastapi_demo', self._pebble_layer, combine=True)
         # Make Pebble reevaluate its plan, ensuring any services are started if enabled.
         container.replan()
         # Learn more about statuses in the SDK docs:
@@ -40,29 +41,29 @@ class FastAPIDemoCharm(ops.CharmBase):
 
     @property
     def _pebble_layer(self) -> ops.pebble.Layer:
-        """Return a Layer object representing a Pebble layer."""
-        command = " ".join(
+        """A Pebble layer for the FastAPI demo services."""
+        command = ' '.join(
             [
-                "uvicorn",
-                "api_demo_server.app:app",
-                "--host=0.0.0.0",
-                "--port=8000",
+                'uvicorn',
+                'api_demo_server.app:app',
+                '--host=0.0.0.0',
+                '--port=8000',
             ]
         )
         pebble_layer: ops.pebble.LayerDict = {
-            "summary": "FastAPI demo service",
-            "description": "pebble config layer for FastAPI demo server",
-            "services": {
+            'summary': 'FastAPI demo service',
+            'description': 'pebble config layer for FastAPI demo server',
+            'services': {
                 self.pebble_service_name: {
-                    "override": "replace",
-                    "summary": "fastapi demo",
-                    "command": command,
-                    "startup": "enabled",
+                    'override': 'replace',
+                    'summary': 'fastapi demo',
+                    'command': command,
+                    'startup': 'enabled',
                 }
             },
         }
         return ops.pebble.Layer(pebble_layer)
 
 
-if __name__ == "__main__":  # pragma: nocover
+if __name__ == '__main__':  # pragma: nocover
     ops.main(FastAPIDemoCharm)


### PR DESCRIPTION
Add type hints for a better developer experience, updating docstrings for consistency.

Note also the change to `on["demo-server"].pebble_ready` which provides better typing and imo should be the recommended way to access bound events for `observe`.

PRs for following branches with additional type hinting incoming.