### PR TITLE
feat: put tests into each chapter - 01_create_minimal_charm

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          channel: 1.32-strict/stable
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,6 +45,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,41 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - 01_create_minimal_charm
+      - 02_make_your_charm_configurable
+      - 04_integrate_with_psql
+      - 06_create_actions
+      - 07_cos_integration
+  pull_request:
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install tox
+        run: pip install tox~=4.24
+      - name: Run linting
+        run: tox -e lint
+
+  unit-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install tox
+        run: pip install tox~=4.24
+      - name: Run tests
+        run: tox -e unit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.32-strict/stable
+          channel: 1.28-strict/stable
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,12 @@ on:
       - 06_create_actions
       - 07_cos_integration
   pull_request:
+    branches:
+      - 01_create_minimal_charm
+      - 02_make_your_charm_configurable
+      - 04_integrate_with_psql
+      - 06_create_actions
+      - 07_cos_integration
   workflow_call:
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.28-strict/stable
+          channel: 1.32-strict/stable
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,3 +39,17 @@ jobs:
         run: pip install tox~=4.24
       - name: Run tests
         run: tox -e unit
+
+  integration-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install tox
+        run: pip install tox~=4.24
+      - name: Run tests
+        run: tox -e integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+# Testing tools configuration
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+log_cli_level = "INFO"
+
+# Linting tools configuration
+[tool.ruff]
+line-length = 99
+lint.select = ["E", "W", "F", "C", "N", "D", "I001"]
+lint.extend-ignore = [
+    "D105",
+    "D107",
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+extend-exclude = ["__pycache__", "*.egg_info"]
+lint.per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
+
+[tool.pyright]
+include = ["src/**.py"]

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,8 +16,10 @@ class FastAPIDemoCharm(ops.CharmBase):
 
     def __init__(self, framework: ops.Framework) -> None:
         super().__init__(framework)
-        self.pebble_service_name = 'fastapi-service'
-        framework.observe(self.on.demo_server_pebble_ready, self._on_demo_server_pebble_ready)
+        self.pebble_service_name = "fastapi-service"
+        framework.observe(
+            self.on.demo_server_pebble_ready, self._on_demo_server_pebble_ready
+        )
 
     def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
         """Define and start a workload using the Pebble API.
@@ -32,7 +34,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         # Get a reference the container attribute on the PebbleReadyEvent
         container = event.workload
         # Add initial Pebble config layer using the Pebble API
-        container.add_layer('fastapi_demo', self._pebble_layer, combine=True)
+        container.add_layer("fastapi_demo", self._pebble_layer, combine=True)
         # Make Pebble reevaluate its plan, ensuring any services are started if enabled.
         container.replan()
         # Learn more about statuses in the SDK docs:
@@ -42,28 +44,26 @@ class FastAPIDemoCharm(ops.CharmBase):
     @property
     def _pebble_layer(self) -> ops.pebble.Layer:
         """A Pebble layer for the FastAPI demo services."""
-        command = ' '.join(
-            [
-                'uvicorn',
-                'api_demo_server.app:app',
-                '--host=0.0.0.0',
-                '--port=8000',
-            ]
-        )
+        command = " ".join([
+            "uvicorn",
+            "api_demo_server.app:app",
+            "--host=0.0.0.0",
+            "--port=8000",
+        ])
         pebble_layer: ops.pebble.LayerDict = {
-            'summary': 'FastAPI demo service',
-            'description': 'pebble config layer for FastAPI demo server',
-            'services': {
+            "summary": "FastAPI demo service",
+            "description": "pebble config layer for FastAPI demo server",
+            "services": {
                 self.pebble_service_name: {
-                    'override': 'replace',
-                    'summary': 'fastapi demo',
-                    'command': command,
-                    'startup': 'enabled',
+                    "override": "replace",
+                    "summary": "fastapi demo",
+                    "command": command,
+                    "startup": "enabled",
                 }
             },
         }
         return ops.pebble.Layer(pebble_layer)
 
 
-if __name__ == '__main__':  # pragma: nocover
+if __name__ == "__main__":  # pragma: nocover
     ops.main(FastAPIDemoCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2025 Ubuntu
 # See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk
+
+"""Charm the application."""
+
 import logging
 
 import ops
@@ -17,9 +20,7 @@ class FastAPIDemoCharm(ops.CharmBase):
     def __init__(self, framework: ops.Framework) -> None:
         super().__init__(framework)
         self.pebble_service_name = "fastapi-service"
-        framework.observe(
-            self.on.demo_server_pebble_ready, self._on_demo_server_pebble_ready
-        )
+        framework.observe(self.on.demo_server_pebble_ready, self._on_demo_server_pebble_ready)
 
     def _on_demo_server_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
         """Define and start a workload using the Pebble API.
@@ -44,12 +45,14 @@ class FastAPIDemoCharm(ops.CharmBase):
     @property
     def _pebble_layer(self) -> ops.pebble.Layer:
         """A Pebble layer for the FastAPI demo services."""
-        command = " ".join([
-            "uvicorn",
-            "api_demo_server.app:app",
-            "--host=0.0.0.0",
-            "--port=8000",
-        ])
+        command = " ".join(
+            [
+                "uvicorn",
+                "api_demo_server.app:app",
+                "--host=0.0.0.0",
+                "--port=8000",
+            ]
+        )
         pebble_layer: ops.pebble.LayerDict = {
             "summary": "FastAPI demo service",
             "description": "pebble config layer for FastAPI demo server",

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Ubuntu
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -28,8 +28,6 @@ async def test_build_and_deploy(ops_test: OpsTest):
         "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
     }
 
-    # Deploy the charm and wait for blocked/idle status
-    # The app will not be in active status as this requires a database relation
     await asyncio.gather(
         ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME),
         ops_test.model.wait_for_idle(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -33,6 +33,6 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await asyncio.gather(
         ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME),
         ops_test.model.wait_for_idle(
-            apps=[APP_NAME], status="blocked", raise_on_blocked=False, timeout=300
+            apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=300
         ),
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+APP_NAME = METADATA["name"]
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest):
+    """Build the charm-under-test and deploy it together with related charms.
+
+    Assert on the unit status before any relations/configurations take place.
+    """
+    # Build and deploy charm from local source folder
+    charm = await ops_test.build_charm(".")
+    resources = {
+        "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
+    }
+
+    # Deploy the charm and wait for blocked/idle status
+    # The app will not be in active status as this requires a database relation
+    await asyncio.gather(
+        ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME),
+        ops_test.model.wait_for_idle(
+            apps=[APP_NAME], status="blocked", raise_on_blocked=False, timeout=120
+        ),
+    )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -33,6 +33,6 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await asyncio.gather(
         ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME),
         ops_test.model.wait_for_idle(
-            apps=[APP_NAME], status="blocked", raise_on_blocked=False, timeout=120
+            apps=[APP_NAME], status="blocked", raise_on_blocked=False, timeout=300
         ),
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,27 +6,25 @@
 import ops
 from ops import testing
 
-
 from charm import FastAPIDemoCharm
 
 
 def test_pebble_layer():
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name="demo-server", can_connect=True)
+    container = testing.Container(name='demo-server', can_connect=True)
     state_in = testing.State(
         containers={container},
         leader=True,
     )
-    ctx.run(ctx.on.pebble_ready(container=container), state_in)
-
+    state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
     # Expected plan after Pebble ready with default config
     expected_plan = {
-        "services": {
-            "fastapi-service": {
-                "override": "replace",
-                "summary": "fastapi demo",
-                "command": "uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000",
-                "startup": "enabled",
+        'services': {
+            'fastapi-service': {
+                'override': 'replace',
+                'summary': 'fastapi demo',
+                'command': 'uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000',
+                'startup': 'enabled',
                 # Since the environment is empty, Layer.to_dict() will not
                 # include it.
             }
@@ -34,8 +32,8 @@ def test_pebble_layer():
     }
 
     # Check that we have the plan we expected:
-    assert container.plan == expected_plan
+    assert state_out.get_container(container.name).plan == expected_plan
     # Check the service was started:
     assert (
-        container.service_statuses["fastapi-service"] == ops.pebble.ServiceStatus.ACTIVE
+        container.service_statuses['fastapi-service'] == ops.pebble.ServiceStatus.ACTIVE
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -33,5 +33,7 @@ def test_pebble_layer():
 
     # Check that we have the plan we expected:
     assert state_out.get_container(container.name).plan == expected_plan
+    # Check the unit status is active
+    assert state_out.unit_status == testing.ActiveStatus()
     # Check the service was started:
     assert container.service_statuses["fastapi-service"] == ops.pebble.ServiceStatus.ACTIVE

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more at: https://juju.is/docs/sdk
+import ops
+from ops import testing
+
+
+from charm import FastAPIDemoCharm
+
+
+def test_pebble_layer():
+    ctx = testing.Context(FastAPIDemoCharm)
+    container = testing.Container(name="demo-server", can_connect=True)
+    state_in = testing.State(
+        containers={container},
+        leader=True,
+    )
+    ctx.run(ctx.on.pebble_ready(container=container), state_in)
+
+    # Expected plan after Pebble ready with default config
+    expected_plan = {
+        "services": {
+            "fastapi-service": {
+                "override": "replace",
+                "summary": "fastapi demo",
+                "command": "uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000",
+                "startup": "enabled",
+                # Since the environment is empty, Layer.to_dict() will not
+                # include it.
+            }
+        }
+    }
+
+    # Check that we have the plan we expected:
+    assert container.plan == expected_plan
+    # Check the service was started:
+    assert (
+        container.service_statuses["fastapi-service"] == ops.pebble.ServiceStatus.ACTIVE
+    )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -34,6 +34,4 @@ def test_pebble_layer():
     # Check that we have the plan we expected:
     assert state_out.get_container(container.name).plan == expected_plan
     # Check the service was started:
-    assert (
-        container.service_statuses["fastapi-service"] == ops.pebble.ServiceStatus.ACTIVE
-    )
+    assert container.service_statuses["fastapi-service"] == ops.pebble.ServiceStatus.ACTIVE

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,7 +11,7 @@ from charm import FastAPIDemoCharm
 
 def test_pebble_layer():
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name='demo-server', can_connect=True)
+    container = testing.Container(name="demo-server", can_connect=True)
     state_in = testing.State(
         containers={container},
         leader=True,
@@ -19,12 +19,12 @@ def test_pebble_layer():
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
     # Expected plan after Pebble ready with default config
     expected_plan = {
-        'services': {
-            'fastapi-service': {
-                'override': 'replace',
-                'summary': 'fastapi demo',
-                'command': 'uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000',
-                'startup': 'enabled',
+        "services": {
+            "fastapi-service": {
+                "override": "replace",
+                "summary": "fastapi demo",
+                "command": "uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000",
+                "startup": "enabled",
                 # Since the environment is empty, Layer.to_dict() will not
                 # include it.
             }
@@ -35,5 +35,5 @@ def test_pebble_layer():
     assert state_out.get_container(container.name).plan == expected_plan
     # Check the service was started:
     assert (
-        container.service_statuses['fastapi-service'] == ops.pebble.ServiceStatus.ACTIVE
+        container.service_statuses["fastapi-service"] == ops.pebble.ServiceStatus.ACTIVE
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,39 @@
+# Copyright 2023 benjamin
+# See LICENSE file for licensing details.
+
+[tox]
+no_package = True
+skip_missing_interpreters = True
+min_version = 4.0.0
+env_list = unit
+
+[vars]
+src_path = {tox_root}/src
+tests_path = {tox_root}/tests
+
+[testenv]
+set_env =
+    PYTHONPATH = {tox_root}/lib:{[vars]src_path}
+    PYTHONBREAKPOINT=pdb.set_trace
+    PY_COLORS=1
+pass_env =
+    PYTHONPATH
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
+
+[testenv:unit]
+description = Run scenario tests
+deps =
+    pytest
+    ops[testing]
+    coverage[toml]
+    -r {tox_root}/requirements.txt
+commands =
+    coverage run --source={[vars]src_path} \
+                 -m pytest \
+                 --tb native \
+                 -v \
+                 -s \
+                 {posargs} \
+                 {[vars]tests_path}/unit
+    coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,16 @@ pass_env =
     CHARM_BUILD_DIR
     MODEL_SETTINGS
 
+[testenv:lint]
+description = Check code against coding style standards
+deps =
+    ruff==0.7.0
+    codespell==2.3.0
+commands =
+    ruff check --preview
+    ruff format --preview --check
+    codespell
+
 [testenv:unit]
 description = Run scenario tests
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,17 @@
-# Copyright 2023 benjamin
+# Copyright 2025 Ubuntu
 # See LICENSE file for licensing details.
 
 [tox]
 no_package = True
 skip_missing_interpreters = True
+env_list = format, lint, static, unit
 min_version = 4.0.0
-env_list = unit
 
 [vars]
 src_path = {tox_root}/src
 tests_path = {tox_root}/tests
+;lib_path = {tox_root}/lib/charms/operator_name_with_underscores
+all_path = {[vars]src_path} {[vars]tests_path}
 
 [testenv]
 set_env =
@@ -21,22 +23,33 @@ pass_env =
     CHARM_BUILD_DIR
     MODEL_SETTINGS
 
+[testenv:format]
+description = Apply coding style standards to code
+deps =
+    ruff
+commands =
+    ruff format {[vars]all_path}
+    ruff check --fix {[vars]all_path}
+
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    ruff==0.7.0
-    codespell==2.3.0
-commands =
-    ruff check --preview
-    ruff format --preview --check
+    ruff
     codespell
+commands =
+    # if this charm owns a lib, uncomment "lib_path" variable
+    # and uncomment the following line
+    # codespell {[vars]lib_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
+    ruff format --check --diff {[vars]all_path}
 
 [testenv:unit]
-description = Run scenario tests
+description = Run unit tests
 deps =
     pytest
-    ops[testing]
     coverage[toml]
+    ops[testing]
     -r {tox_root}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
@@ -47,3 +60,27 @@ commands =
                  {posargs} \
                  {[vars]tests_path}/unit
     coverage report
+
+[testenv:static]
+description = Run static type checks
+deps =
+    pyright
+    ops[testing]
+    -r {tox_root}/requirements.txt
+commands =
+    pyright {posargs}
+
+[testenv:integration]
+description = Run integration tests
+deps =
+    pytest
+    juju
+    pytest-operator
+    -r {tox_root}/requirements.txt
+commands =
+    pytest -v \
+           -s \
+           --tb native \
+           --log-cli-level=INFO \
+           {posargs} \
+           {[vars]tests_path}/integration


### PR DESCRIPTION
Add unit test to the first chapter, including CI.

Changes:

- Add CI from the main branch, see [the previous PR](https://github.com/canonical/juju-sdk-tutorial-k8s/pull/66).
- Rewrite the harness unit test for the Pebble layer in Scenario.
- Move an integration test from a latter chapter into this one.
- Add `pyproject.toml` and `tox.ini` from the latest `charmcraft init`.
- `tox -e format` and `tox -e lint` using the default settings in `pyproject.toml` from `charmcraft init`.