### PR TITLE
chore: add github actions and tox/pyproject config from charmcraft init

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,41 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - 01_create_minimal_charm
+      - 02_make_your_charm_configurable
+      - 04_integrate_with_psql
+      - 06_create_actions
+      - 07_cos_integration
+  pull_request:
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install tox
+        run: pip install tox~=4.24
+      - name: Run linting
+        run: tox -e lint
+
+  unit-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install tox
+        run: pip install tox~=4.24
+      - name: Run tests
+        run: tox -e unit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,3 +39,17 @@ jobs:
         run: pip install tox~=4.24
       - name: Run tests
         run: tox -e unit
+
+  integration-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install tox
+        run: pip install tox~=4.24
+      - name: Run tests
+        run: tox -e integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+# Testing tools configuration
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+log_cli_level = "INFO"
+
+# Linting tools configuration
+[tool.ruff]
+line-length = 99
+lint.select = ["E", "W", "F", "C", "N", "D", "I001"]
+lint.extend-ignore = [
+    "D105",
+    "D107",
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+extend-exclude = ["__pycache__", "*.egg_info"]
+lint.per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
+
+[tool.pyright]
+include = ["src/**.py"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,86 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Ubuntu
 # See LICENSE file for licensing details.
+
 [tox]
-requires =
-    tox>=4
-envlist = make-prs
+no_package = True
+skip_missing_interpreters = True
+env_list = format, lint, static, unit
+min_version = 4.0.0
+
+[vars]
+src_path = {tox_root}/src
+tests_path = {tox_root}/tests
+;lib_path = {tox_root}/lib/charms/operator_name_with_underscores
+all_path = {[vars]src_path} {[vars]tests_path}
 
 [testenv]
-basepython = python3
-setenv =
-  PY_COLORS=1
-passenv =
-  GITHUB_TOKEN
+set_env =
+    PYTHONPATH = {tox_root}/lib:{[vars]src_path}
+    PYTHONBREAKPOINT=pdb.set_trace
+    PY_COLORS=1
+pass_env =
+    PYTHONPATH
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
 
-[testenv:make-prs]
-description = Make pull requests for the tutorial repository
-commands_pre =
-    pip install -r requirements.txt
-commands =
-    python make-prs.py {posargs}
-
-[testenv:fmt]
+[testenv:format]
 description = Apply coding style standards to code
 deps =
-    ruff==0.4.5
+    ruff
 commands =
-    ruff check --select I --fix
-    ruff format --line-length=99 --preview .
+    ruff format {[vars]all_path}
+    ruff check --fix {[vars]all_path}
+
+[testenv:lint]
+description = Check code against coding style standards
+deps =
+    ruff
+    codespell
+commands =
+    # if this charm owns a lib, uncomment "lib_path" variable
+    # and uncomment the following line
+    # codespell {[vars]lib_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
+    ruff format --check --diff {[vars]all_path}
+
+[testenv:unit]
+description = Run unit tests
+deps =
+    pytest
+    coverage[toml]
+    ops[testing]
+    -r {tox_root}/requirements.txt
+commands =
+    coverage run --source={[vars]src_path} \
+                 -m pytest \
+                 --tb native \
+                 -v \
+                 -s \
+                 {posargs} \
+                 {[vars]tests_path}/unit
+    coverage report
+
+[testenv:static]
+description = Run static type checks
+deps =
+    pyright
+    ops[testing]
+    -r {tox_root}/requirements.txt
+commands =
+    pyright {posargs}
+
+[testenv:integration]
+description = Run integration tests
+deps =
+    pytest
+    juju
+    pytest-operator
+    -r {tox_root}/requirements.txt
+commands =
+    pytest -v \
+           -s \
+           --tb native \
+           --log-cli-level=INFO \
+           {posargs} \
+           {[vars]tests_path}/integration

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2025 Ubuntu
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]
@@ -22,6 +22,14 @@ pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
     MODEL_SETTINGS
+    GITHUB_TOKEN
+
+[testenv:make-prs]
+description = Make pull requests for the tutorial repository
+commands_pre =
+    pip install -r requirements.txt
+commands =
+    python make-prs.py {posargs}
 
 [testenv:format]
 description = Apply coding style standards to code


### PR DESCRIPTION
Add GitHub Actions to run tests for each chapter, and update `tox.ini` and `pyproject.toml` (needed for tox lint/format) from latest `charmcraft init`.