### PR TITLE
feat: put tests into each chapter - 04_integrate_with_psql

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,12 @@ on:
       - 06_create_actions
       - 07_cos_integration
   pull_request:
+    branches:
+      - 01_create_minimal_charm
+      - 02_make_your_charm_configurable
+      - 04_integrate_with_psql
+      - 06_create_actions
+      - 07_cos_integration
   workflow_call:
 
 jobs:
@@ -45,6 +51,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+          channel: 1.32-strict/stable
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,55 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - 01_create_minimal_charm
+      - 02_make_your_charm_configurable
+      - 04_integrate_with_psql
+      - 06_create_actions
+      - 07_cos_integration
+  pull_request:
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install tox
+        run: pip install tox~=4.24
+      - name: Run linting
+        run: tox -e lint
+
+  unit-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install tox
+        run: pip install tox~=4.24
+      - name: Run tests
+        run: tox -e unit
+
+  integration-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install tox
+        run: pip install tox~=4.24
+      - name: Run tests
+        run: tox -e integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+# Testing tools configuration
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+log_cli_level = "INFO"
+
+# Linting tools configuration
+[tool.ruff]
+line-length = 99
+lint.select = ["E", "W", "F", "C", "N", "D", "I001"]
+lint.extend-ignore = [
+    "D105",
+    "D107",
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+extend-exclude = ["__pycache__", "*.egg_info"]
+lint.per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
+
+[tool.pyright]
+include = ["src/**.py"]

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2025 Ubuntu
 # See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk
+
+"""Charm the application."""
+
 import logging
 from typing import Dict, Optional
 
 import ops
 import requests
-from charms.data_platform_libs.v0.data_interfaces import DatabaseCreatedEvent
-from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
+from charms.data_platform_libs.v0.data_interfaces import DatabaseCreatedEvent, DatabaseRequires
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
@@ -20,45 +22,45 @@ class FastAPIDemoCharm(ops.CharmBase):
 
     def __init__(self, framework: ops.Framework) -> None:
         super().__init__(framework)
-        self.pebble_service_name = 'fastapi-service'
+        self.pebble_service_name = "fastapi-service"
         self.container = self.unit.get_container(
-            'demo-server'
+            "demo-server"
         )  # see 'containers' in charmcraft.yaml
         framework.observe(self.on.demo_server_pebble_ready, self._on_demo_server_pebble_ready)
         framework.observe(self.on.config_changed, self._on_config_changed)
         framework.observe(self.on.collect_unit_status, self._on_collect_status)
         # Charm events defined in the database requires charm library:
-        self.database = DatabaseRequires(self, relation_name='database', database_name='names_db')
+        self.database = DatabaseRequires(self, relation_name="database", database_name="names_db")
         framework.observe(self.database.on.database_created, self._on_database_created)
         framework.observe(self.database.on.endpoints_changed, self._on_database_created)
 
     def _on_collect_status(self, event: ops.CollectStatusEvent) -> None:
-        port = self.config['server-port']
+        port = self.config["server-port"]
         if port == 22:
-            event.add_status(ops.BlockedStatus('Invalid port number, 22 is reserved for SSH'))
-        if not self.model.get_relation('database'):
+            event.add_status(ops.BlockedStatus("Invalid port number, 22 is reserved for SSH"))
+        if not self.model.get_relation("database"):
             # We need the user to do 'juju integrate'.
-            event.add_status(ops.BlockedStatus('Waiting for database relation'))
+            event.add_status(ops.BlockedStatus("Waiting for database relation"))
         elif not self.database.fetch_relation_data():
             # We need the charms to finish integrating.
-            event.add_status(ops.WaitingStatus('Waiting for database relation'))
+            event.add_status(ops.WaitingStatus("Waiting for database relation"))
         try:
             status = self.container.get_service(self.pebble_service_name)
         except (ops.pebble.APIError, ops.ModelError):
-            event.add_status(ops.MaintenanceStatus('Waiting for Pebble in workload container'))
+            event.add_status(ops.MaintenanceStatus("Waiting for Pebble in workload container"))
         else:
             if not status.is_running():
-                event.add_status(ops.MaintenanceStatus('Waiting for the service to start up'))
+                event.add_status(ops.MaintenanceStatus("Waiting for the service to start up"))
         # If nothing is wrong, then the status is active.
         event.add_status(ops.ActiveStatus())
 
     def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
-        port = self.config['server-port']  # see charmcraft.yaml
-        logger.debug('New application port is requested: %s', port)
+        port = self.config["server-port"]  # see charmcraft.yaml
+        logger.debug("New application port is requested: %s", port)
 
         if port == 22:
             # The collect-status handler will set the status to blocked.
-            logger.info('Invalid port number, 22 is reserved for SSH')
+            logger.info("Invalid port number, 22 is reserved for SSH")
             return
 
         self._update_layer_and_restart()
@@ -81,30 +83,30 @@ class FastAPIDemoCharm(ops.CharmBase):
         Learn more about Pebble layers at
             https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/layers
         """
-
         # Learn more about statuses in the SDK docs:
         # https://juju.is/docs/sdk/constructs#heading--statuses
-        self.unit.status = ops.MaintenanceStatus('Assembling Pebble layers')
+        self.unit.status = ops.MaintenanceStatus("Assembling Pebble layers")
         try:
             # Get the current pebble layer config
-            services = self.container.get_plan().to_dict().get('services', {})
-            if services != self._pebble_layer.to_dict().get('services', {}):
+            services = self.container.get_plan().to_dict().get("services", {})
+            if services != self._pebble_layer.to_dict().get("services", {}):
                 # Changes were made, add the new layer
-                self.container.add_layer('fastapi_demo', self._pebble_layer, combine=True)
+                self.container.add_layer("fastapi_demo", self._pebble_layer, combine=True)
                 logger.info("Added updated layer 'fastapi_demo' to Pebble plan")
 
                 self.container.restart(self.pebble_service_name)
                 logger.info(f"Restarted '{self.pebble_service_name}' service")
         except ops.pebble.APIError as e:
-            logger.info('Unable to connect to Pebble: %s', e)
+            logger.info("Unable to connect to Pebble: %s", e)
             return
         # Add workload version in Juju status.
         self.unit.set_workload_version(self.version)
 
     @property
     def app_environment(self) -> Dict[str, Optional[str]]:
-        """This property method creates a dictionary containing environment variables
-        for the application. It retrieves the database authentication data by calling
+        """Creates a dictionary containing environment variables for the application.
+
+        It retrieves the database authentication data by calling
         the `fetch_postgres_relation_data` method and uses it to populate the dictionary.
         If any of the values are not present, it will be set to None.
         The method returns this dictionary as output.
@@ -113,10 +115,10 @@ class FastAPIDemoCharm(ops.CharmBase):
         if not db_data:
             return {}
         env = {
-            'DEMO_SERVER_DB_HOST': db_data.get('db_host', None),
-            'DEMO_SERVER_DB_PORT': db_data.get('db_port', None),
-            'DEMO_SERVER_DB_USER': db_data.get('db_username', None),
-            'DEMO_SERVER_DB_PASSWORD': db_data.get('db_password', None),
+            "DEMO_SERVER_DB_HOST": db_data.get("db_host", None),
+            "DEMO_SERVER_DB_PORT": db_data.get("db_port", None),
+            "DEMO_SERVER_DB_USER": db_data.get("db_username", None),
+            "DEMO_SERVER_DB_PASSWORD": db_data.get("db_password", None),
         }
         return env
 
@@ -128,19 +130,20 @@ class FastAPIDemoCharm(ops.CharmBase):
         then logged for debugging purposes, and any non-empty data is processed to extract
         endpoint information, username, and password. This processed data is then returned as
         a dictionary. If no data is retrieved, the unit is set to waiting status and
-        the program exits with a zero status code."""
+        the program exits with a zero status code.
+        """
         relations = self.database.fetch_relation_data()
-        logger.debug('Got following database data: %s', relations)
+        logger.debug("Got following database data: %s", relations)
         for data in relations.values():
             if not data:
                 continue
-            logger.info('New PSQL database endpoint is %s', data['endpoints'])
-            host, port = data['endpoints'].split(':')
+            logger.info("New PSQL database endpoint is %s", data["endpoints"])
+            host, port = data["endpoints"].split(":")
             db_data = {
-                'db_host': host,
-                'db_port': port,
-                'db_username': data['username'],
-                'db_password': data['password'],
+                "db_host": host,
+                "db_port": port,
+                "db_username": data["username"],
+                "db_password": data["password"],
             }
             return db_data
         return {}
@@ -148,24 +151,24 @@ class FastAPIDemoCharm(ops.CharmBase):
     @property
     def _pebble_layer(self) -> ops.pebble.Layer:
         """A Pebble layer for the FastAPI demo services."""
-        command = ' '.join(
+        command = " ".join(
             [
-                'uvicorn',
-                'api_demo_server.app:app',
-                '--host=0.0.0.0',
+                "uvicorn",
+                "api_demo_server.app:app",
+                "--host=0.0.0.0",
                 f"--port={self.config['server-port']}",
             ]
         )
         pebble_layer: ops.pebble.LayerDict = {
-            'summary': 'FastAPI demo service',
-            'description': 'pebble config layer for FastAPI demo server',
-            'services': {
+            "summary": "FastAPI demo service",
+            "description": "pebble config layer for FastAPI demo server",
+            "services": {
                 self.pebble_service_name: {
-                    'override': 'replace',
-                    'summary': 'fastapi demo',
-                    'command': command,
-                    'startup': 'enabled',
-                    'environment': self.app_environment,
+                    "override": "replace",
+                    "summary": "fastapi demo",
+                    "command": command,
+                    "startup": "enabled",
+                    "environment": self.app_environment,
                 }
             },
         }
@@ -180,14 +183,14 @@ class FastAPIDemoCharm(ops.CharmBase):
         # Catching Exception is not ideal, but we don't care much for the error here, and just
         # default to setting a blank version since there isn't much the admin can do!
         except Exception as e:
-            logger.warning('unable to get version from API: %s', str(e), exc_info=True)
-        return ''
+            logger.warning("unable to get version from API: %s", str(e), exc_info=True)
+        return ""
 
     def _request_version(self) -> str:
-        """Helper for fetching the version from the running workload using the API."""
+        """Fetch the version from the running workload using the API."""
         resp = requests.get(f"http://localhost:{self.config['server-port']}/version", timeout=10)
-        return resp.json()['version']
+        return resp.json()["version"]
 
 
-if __name__ == '__main__':  # pragma: nocover
+if __name__ == "__main__":  # pragma: nocover
     ops.main(FastAPIDemoCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -104,7 +104,7 @@ class FastAPIDemoCharm(ops.CharmBase):
 
     @property
     def app_environment(self) -> Dict[str, Optional[str]]:
-        """Creates a dictionary containing environment variables for the application.
+        """Create a dictionary containing environment variables for the application.
 
         It retrieves the database authentication data by calling
         the `fetch_postgres_relation_data` method and uses it to populate the dictionary.

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Ubuntu
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk

--- a/src/charm.py
+++ b/src/charm.py
@@ -96,7 +96,7 @@ class FastAPIDemoCharm(ops.CharmBase):
 
                 self.container.restart(self.pebble_service_name)
                 logger.info(f"Restarted '{self.pebble_service_name}' service")
-        except ops.pebble.APIError as e:
+        except (ops.pebble.APIError, ops.pebble.ConnectionError) as e:
             logger.info("Unable to connect to Pebble: %s", e)
             return
         # Add workload version in Juju status.

--- a/src/charm.py
+++ b/src/charm.py
@@ -46,7 +46,7 @@ class FastAPIDemoCharm(ops.CharmBase):
             event.add_status(ops.WaitingStatus("Waiting for database relation"))
         try:
             status = self.container.get_service(self.pebble_service_name)
-        except (ops.pebble.APIError, ops.ModelError):
+        except (ops.pebble.APIError, ops.pebble.ConnectionError, ops.ModelError):
             event.add_status(ops.MaintenanceStatus("Waiting for Pebble in workload container"))
         else:
             if not status.is_running():

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -36,3 +36,20 @@ async def test_build_and_deploy(ops_test: OpsTest):
             apps=[APP_NAME], status="blocked", raise_on_blocked=False, timeout=120
         ),
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_database_integration(ops_test: OpsTest):
+    """Verify that the charm integrates with the database.
+
+    Assert that the charm is active if the integration is established.
+    """
+    await ops_test.model.deploy(
+        application_name="postgresql-k8s",
+        entity_url="postgresql-k8s",
+        channel="14/stable",
+    )
+    await ops_test.model.integrate(f"{APP_NAME}", "postgresql-k8s")
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=120
+    )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -33,7 +33,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await asyncio.gather(
         ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME),
         ops_test.model.wait_for_idle(
-            apps=[APP_NAME], status="blocked", raise_on_blocked=False, timeout=120
+            apps=[APP_NAME], status="blocked", raise_on_blocked=False, timeout=300
         ),
     )
 
@@ -51,5 +51,5 @@ async def test_database_integration(ops_test: OpsTest):
     )
     await ops_test.model.integrate(f"{APP_NAME}", "postgresql-k8s")
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=120
+        apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=300
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+APP_NAME = METADATA["name"]
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest):
+    """Build the charm-under-test and deploy it together with related charms.
+
+    Assert on the unit status before any relations/configurations take place.
+    """
+    # Build and deploy charm from local source folder
+    charm = await ops_test.build_charm(".")
+    resources = {
+        "demo-server-image": METADATA["resources"]["demo-server-image"]["upstream-source"]
+    }
+
+    # Deploy the charm and wait for blocked/idle status
+    # The app will not be in active status as this requires a database relation
+    await asyncio.gather(
+        ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME),
+        ops_test.model.wait_for_idle(
+            apps=[APP_NAME], status="blocked", raise_on_blocked=False, timeout=120
+        ),
+    )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more at: https://juju.is/docs/sdk
+import ops
+from ops import testing
+
+from charm import FastAPIDemoCharm
+
+
+def test_pebble_layer():
+    ctx = testing.Context(FastAPIDemoCharm)
+    container = testing.Container(name='demo-server', can_connect=True)
+    state_in = testing.State(
+        containers={container},
+        leader=True,
+    )
+    state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
+    # Expected plan after Pebble ready with default config
+    expected_plan = {
+        'services': {
+            'fastapi-service': {
+                'override': 'replace',
+                'summary': 'fastapi demo',
+                'command': 'uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000',
+                'startup': 'enabled',
+                # Since the environment is empty, Layer.to_dict() will not
+                # include it.
+            }
+        }
+    }
+
+    # Check that we have the plan we expected:
+    assert state_out.get_container(container.name).plan == expected_plan
+    # Check the service was started:
+    assert (
+        container.service_statuses['fastapi-service'] == ops.pebble.ServiceStatus.ACTIVE
+    )
+
+
+def test_config_changed():
+    ctx = testing.Context(FastAPIDemoCharm)
+    container = testing.Container(name='demo-server', can_connect=True)
+    state_in = testing.State(
+        containers={container},
+        config={'server-port': 8080},
+        leader=True,
+    )
+    ctx.run(ctx.on.config_changed(), state_in)
+    assert (
+        '--port=8080'
+        in container.layers['fastapi_demo'].services['fastapi-service'].command
+    )
+
+
+def test_config_changed_invalid_port():
+    ctx = testing.Context(FastAPIDemoCharm)
+    container = testing.Container(name='demo-server', can_connect=True)
+    state_in = testing.State(
+        containers={container},
+        config={'server-port': 22},
+        leader=True,
+    )
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+    assert state_out.unit_status == ops.BlockedStatus(
+        'Invalid port number, 22 is reserved for SSH'
+    )
+
+
+def test_relation_data():
+    ctx = testing.Context(FastAPIDemoCharm)
+    relation = testing.Relation(
+        endpoint='database',
+        interface='postgresql_client',
+        remote_app_name='postgresql-k8s',
+        remote_app_data={
+            'endpoints': 'example.com:5432',
+            'username': 'foo',
+            'password': 'bar',
+        },
+    )
+    container = testing.Container(name='demo-server', can_connect=True)
+    state_in = testing.State(
+        containers={container},
+        relations={relation},
+        leader=True,
+    )
+
+    ctx.run(ctx.on.relation_changed(relation), state_in)
+
+    assert container.layers['fastapi_demo'].services['fastapi-service'].environment == {
+        'DEMO_SERVER_DB_HOST': 'example.com',
+        'DEMO_SERVER_DB_PORT': '5432',
+        'DEMO_SERVER_DB_USER': 'foo',
+        'DEMO_SERVER_DB_PASSWORD': 'bar',
+    }
+
+
+def test_no_database_blocked():
+    ctx = testing.Context(FastAPIDemoCharm)
+    container = testing.Container(name='demo-server', can_connect=True)
+    state_in = testing.State(
+        containers={container},
+        leader=True,
+    )
+
+    state_out = ctx.run(ctx.on.collect_unit_status(), state_in)
+
+    assert state_out.unit_status == ops.BlockedStatus('Waiting for database relation')

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -58,7 +58,7 @@ def test_config_changed_invalid_port():
         leader=True,
     )
     state_out = ctx.run(ctx.on.config_changed(), state_in)
-    assert state_out.unit_status == ops.BlockedStatus(
+    assert state_out.unit_status == testing.BlockedStatus(
         "Invalid port number, 22 is reserved for SSH"
     )
 
@@ -102,4 +102,4 @@ def test_no_database_blocked():
 
     state_out = ctx.run(ctx.on.collect_unit_status(), state_in)
 
-    assert state_out.unit_status == ops.BlockedStatus("Waiting for database relation")
+    assert state_out.unit_status == testing.BlockedStatus("Waiting for database relation")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,7 +11,7 @@ from charm import FastAPIDemoCharm
 
 def test_pebble_layer():
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name='demo-server', can_connect=True)
+    container = testing.Container(name="demo-server", can_connect=True)
     state_in = testing.State(
         containers={container},
         leader=True,
@@ -19,12 +19,12 @@ def test_pebble_layer():
     state_out = ctx.run(ctx.on.pebble_ready(container), state_in)
     # Expected plan after Pebble ready with default config
     expected_plan = {
-        'services': {
-            'fastapi-service': {
-                'override': 'replace',
-                'summary': 'fastapi demo',
-                'command': 'uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000',
-                'startup': 'enabled',
+        "services": {
+            "fastapi-service": {
+                "override": "replace",
+                "summary": "fastapi demo",
+                "command": "uvicorn api_demo_server.app:app --host=0.0.0.0 --port=8000",
+                "startup": "enabled",
                 # Since the environment is empty, Layer.to_dict() will not
                 # include it.
             }
@@ -34,53 +34,48 @@ def test_pebble_layer():
     # Check that we have the plan we expected:
     assert state_out.get_container(container.name).plan == expected_plan
     # Check the service was started:
-    assert (
-        container.service_statuses['fastapi-service'] == ops.pebble.ServiceStatus.ACTIVE
-    )
+    assert container.service_statuses["fastapi-service"] == ops.pebble.ServiceStatus.ACTIVE
 
 
 def test_config_changed():
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name='demo-server', can_connect=True)
+    container = testing.Container(name="demo-server", can_connect=True)
     state_in = testing.State(
         containers={container},
-        config={'server-port': 8080},
+        config={"server-port": 8080},
         leader=True,
     )
     ctx.run(ctx.on.config_changed(), state_in)
-    assert (
-        '--port=8080'
-        in container.layers['fastapi_demo'].services['fastapi-service'].command
-    )
+    assert "--port=8080" in container.layers["fastapi_demo"].services["fastapi-service"].command
 
 
 def test_config_changed_invalid_port():
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name='demo-server', can_connect=True)
+    container = testing.Container(name="demo-server", can_connect=True)
     state_in = testing.State(
         containers={container},
-        config={'server-port': 22},
+        config={"server-port": 22},
         leader=True,
     )
     state_out = ctx.run(ctx.on.config_changed(), state_in)
     assert state_out.unit_status == ops.BlockedStatus(
-        'Invalid port number, 22 is reserved for SSH'
+        "Invalid port number, 22 is reserved for SSH"
     )
 
 
 def test_relation_data():
     ctx = testing.Context(FastAPIDemoCharm)
     relation = testing.Relation(
-        endpoint='database',
-        interface='postgresql_client',
-        remote_app_name='postgresql-k8s',
+        endpoint="database",
+        interface="postgresql_client",
+        remote_app_name="postgresql-k8s",
         remote_app_data={
-            'endpoints': 'example.com:5432',
-            'username': 'foo',
-            'password': 'bar',
+            "endpoints": "example.com:5432",
+            "username": "foo",
+            "password": "bar",
         },
     )
-    container = testing.Container(name='demo-server', can_connect=True)
+    container = testing.Container(name="demo-server", can_connect=True)
     state_in = testing.State(
         containers={container},
         relations={relation},
@@ -89,17 +84,17 @@ def test_relation_data():
 
     ctx.run(ctx.on.relation_changed(relation), state_in)
 
-    assert container.layers['fastapi_demo'].services['fastapi-service'].environment == {
-        'DEMO_SERVER_DB_HOST': 'example.com',
-        'DEMO_SERVER_DB_PORT': '5432',
-        'DEMO_SERVER_DB_USER': 'foo',
-        'DEMO_SERVER_DB_PASSWORD': 'bar',
+    assert container.layers["fastapi_demo"].services["fastapi-service"].environment == {
+        "DEMO_SERVER_DB_HOST": "example.com",
+        "DEMO_SERVER_DB_PORT": "5432",
+        "DEMO_SERVER_DB_USER": "foo",
+        "DEMO_SERVER_DB_PASSWORD": "bar",
     }
 
 
 def test_no_database_blocked():
     ctx = testing.Context(FastAPIDemoCharm)
-    container = testing.Container(name='demo-server', can_connect=True)
+    container = testing.Container(name="demo-server", can_connect=True)
     state_in = testing.State(
         containers={container},
         leader=True,
@@ -107,4 +102,4 @@ def test_no_database_blocked():
 
     state_out = ctx.run(ctx.on.collect_unit_status(), state_in)
 
-    assert state_out.unit_status == ops.BlockedStatus('Waiting for database relation')
+    assert state_out.unit_status == ops.BlockedStatus("Waiting for database relation")

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,39 @@
+# Copyright 2023 benjamin
+# See LICENSE file for licensing details.
+
+[tox]
+no_package = True
+skip_missing_interpreters = True
+min_version = 4.0.0
+env_list = unit
+
+[vars]
+src_path = {tox_root}/src
+tests_path = {tox_root}/tests
+
+[testenv]
+set_env =
+    PYTHONPATH = {tox_root}/lib:{[vars]src_path}
+    PYTHONBREAKPOINT=pdb.set_trace
+    PY_COLORS=1
+pass_env =
+    PYTHONPATH
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
+
+[testenv:unit]
+description = Run scenario tests
+deps =
+    pytest
+    ops[testing]
+    coverage[toml]
+    -r {tox_root}/requirements.txt
+commands =
+    coverage run --source={[vars]src_path} \
+                 -m pytest \
+                 --tb native \
+                 -v \
+                 -s \
+                 {posargs} \
+                 {[vars]tests_path}/unit
+    coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,17 @@
-# Copyright 2023 benjamin
+# Copyright 2025 Ubuntu
 # See LICENSE file for licensing details.
 
 [tox]
 no_package = True
 skip_missing_interpreters = True
+env_list = format, lint, static, unit
 min_version = 4.0.0
-env_list = unit
 
 [vars]
 src_path = {tox_root}/src
 tests_path = {tox_root}/tests
+;lib_path = {tox_root}/lib/charms/operator_name_with_underscores
+all_path = {[vars]src_path} {[vars]tests_path}
 
 [testenv]
 set_env =
@@ -21,12 +23,33 @@ pass_env =
     CHARM_BUILD_DIR
     MODEL_SETTINGS
 
+[testenv:format]
+description = Apply coding style standards to code
+deps =
+    ruff
+commands =
+    ruff format {[vars]all_path}
+    ruff check --fix {[vars]all_path}
+
+[testenv:lint]
+description = Check code against coding style standards
+deps =
+    ruff
+    codespell
+commands =
+    # if this charm owns a lib, uncomment "lib_path" variable
+    # and uncomment the following line
+    # codespell {[vars]lib_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
+    ruff format --check --diff {[vars]all_path}
+
 [testenv:unit]
-description = Run scenario tests
+description = Run unit tests
 deps =
     pytest
-    ops[testing]
     coverage[toml]
+    ops[testing]
     -r {tox_root}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
@@ -37,3 +60,27 @@ commands =
                  {posargs} \
                  {[vars]tests_path}/unit
     coverage report
+
+[testenv:static]
+description = Run static type checks
+deps =
+    pyright
+    ops[testing]
+    -r {tox_root}/requirements.txt
+commands =
+    pyright {posargs}
+
+[testenv:integration]
+description = Run integration tests
+deps =
+    pytest
+    juju
+    pytest-operator
+    -r {tox_root}/requirements.txt
+commands =
+    pytest -v \
+           -s \
+           --tb native \
+           --log-cli-level=INFO \
+           {posargs} \
+           {[vars]tests_path}/integration


### PR DESCRIPTION
Add unit test to chapter 04, including CI.

Changes:

- Add CI from the main branch, see [the previous PR](https://github.com/canonical/juju-sdk-tutorial-k8s/pull/66).
- Add unit test for relations, and merge unit tests and integration tests from previous chapters into chapter 04.
- Move an integration test from a latter chapter into this one.
- Add `pyproject.toml` and `tox.ini` from the latest `charmcraft init`.
- `tox -e format` and `tox -e lint` using the default settings in `pyproject.toml` from `charmcraft init`.