### PR TITLE
chore: fix integration ci

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,6 +45,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+          channel: 1.32-strict/stable
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,12 @@ on:
       - 06_create_actions
       - 07_cos_integration
   pull_request:
+    branches:
+      - 01_create_minimal_charm
+      - 02_make_your_charm_configurable
+      - 04_integrate_with_psql
+      - 06_create_actions
+      - 07_cos_integration
   workflow_call:
 
 jobs:


### PR DESCRIPTION
Add a missing step for integration CI and use a specific channel for microk8s.

More information: when using the [charmed-kubernetes/actions-operator action](https://github.com/charmed-kubernetes/actions-operator) to setup an environment for integration test, with Juju 3.3+, microk8s needs a strict channel version. Without this setting, there will be an error like `juju "3.x.x" can only work with strictly confined microk8s`. See an [existing issue here](https://github.com/charmed-kubernetes/actions-operator/issues/70) and [an unmerged PR here](https://github.com/charmed-kubernetes/actions-operator/pull/57).

Related: https://github.com/canonical/operator/pull/1644.

Also there is a change to not run unit/integration tests for other branches (like main).