### PR TITLE
chore: change typing annotation Dict to dict

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,7 @@
 
 import json
 import logging
-from typing import Dict, List, Optional, Union, cast
+from typing import List, Optional, Union, cast
 
 import ops
 import requests
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 PEER_NAME = "fastapi-peer"
 
 JSONData = Union[
-    Dict[str, "JSONData"],
+    dict[str, "JSONData"],
     List["JSONData"],
     str,
     int,
@@ -199,7 +199,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         }
         return env
 
-    def fetch_postgres_relation_data(self) -> Dict[str, str]:
+    def fetch_postgres_relation_data(self) -> dict[str, str]:
         """Fetch postgres relation data.
 
         This function retrieves relation data from a postgres database using
@@ -278,7 +278,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         peers = cast(ops.Relation, self.peers)
         peers.data[self.app][key] = json.dumps(data)
 
-    def get_peer_data(self, key: str) -> Dict[str, JSONData]:
+    def get_peer_data(self, key: str) -> dict[str, JSONData]:
         """Retrieve information from the peer data bucket instead of `StoredState`."""
         if not self.peers:
             return {}

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,7 @@
 
 import json
 import logging
-from typing import List, Optional, Union, cast
+from typing import Optional, Union, cast
 
 import ops
 import requests
@@ -24,7 +24,7 @@ PEER_NAME = "fastapi-peer"
 
 JSONData = Union[
     dict[str, "JSONData"],
-    List["JSONData"],
+    list["JSONData"],
     str,
     int,
     float,

--- a/src/charm.py
+++ b/src/charm.py
@@ -176,7 +176,7 @@ class FastAPIDemoCharm(ops.CharmBase):
         self.unit.set_workload_version(self.version)
 
     @property
-    def app_environment(self) -> Dict[str, str]:
+    def app_environment(self) -> dict[str, str]:
         """Create a dictionary containing environment variables for the application.
 
         It retrieves the database authentication data by calling


### PR DESCRIPTION
Per [comment here](https://github.com/canonical/operator/pull/1688#discussion_r2055490697), we should use `dict` instead of `Dict`. The doc is already updated, this PR updates the code in the chapter. Since dropping `Dict` means it only works for 3.9+, it's reasonable to drop `List` and use the native `list` as well according to a discussion with David.