### PR TITLE
docs: replace README by info about latest code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,4 @@
-This repository holds the code for the Charm SDK tutorial for Kubernetes: https://juju.is/docs/sdk/from-zero-to-hero-write-your-first-kubernetes-charm 
+> [!IMPORTANT]
+> This repository is no longer used. The latest code for the Ops [Kubernetes charm tutorial](https://ops.readthedocs.io/en/latest/) is in the [Ops repository](https://github.com/canonical/operator/tree/main/examples).
 
-There is a branch for each chapter. As the chapters build on top of one other, each branch builds on the one before as well. As a result:
-
-- To create a branch for a new chapter: Create it from the latest branch.
-
-- To make a change to a chapter and then propagate it up to all the remaining branches:
-    -  Start with the first branch (Branch A) and make the necessary updates. Commit the changes in Branch A.
-    -  Switch to the second branch (Branch B). Merge the changes from Branch A into Branch B. Resolve any conflicts that arise during the merge process, if applicable. Commit the changes resulting from the merge in Branch B.
-    -  Repeat for each branch until you're done. Your changes should have successfully propagated to all the branches.
-
-⚠️ In either case, once you've made the change in the repository, make sure to update the code in the corresponding tutorial chapter as well. (From the juju.is link, on the bottom of each doc, click on "Help improve this document in the forum", then edit the doc on Discourse. Make sure to also add your name to the list of contributors on the bottom of each doc.)
+This repository contains historical code for the Kubernetes charm tutorial, with a separate branch for each chapter of the tutorial.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 > [!IMPORTANT]
-> This repository is no longer used. The latest code for the Ops [Kubernetes charm tutorial](https://ops.readthedocs.io/en/latest/) is in the [Ops repository](https://github.com/canonical/operator/tree/main/examples).
+> This repository is no longer used. The latest code for the Ops [Kubernetes charm tutorial](https://ops.readthedocs.io/en/latest/tutorial/from-zero-to-hero-write-your-first-kubernetes-charm/index.html) is in the [Ops repository](https://github.com/canonical/operator/tree/main/examples).
 
 This repository contains historical code for the Kubernetes charm tutorial, with a separate branch for each chapter of the tutorial.


### PR DESCRIPTION
In https://github.com/canonical/operator/pull/1898, we removed references to this repo from the Ops docs. The charm charm code is now maintained [in the Ops repo](https://github.com/canonical/operator) instead. This PR replaces the README with a notice that redirects people to the new location.

(I also searched elsewhere for references to this repo and updated one: https://github.com/canonical/postgresql-k8s-operator/pull/1015)